### PR TITLE
Components with Joins

### DIFF
--- a/build/jubilee.js
+++ b/build/jubilee.js
@@ -10119,7 +10119,7 @@ define('src/modules/component/boxplot',['require','d3'],function (require) {
       });
     }
 
-    component.gClass = function (_) {
+    component.class = function (_) {
       if (!arguments.length) { return gClass; }
       gClass = _;
       return component;
@@ -10369,6 +10369,8 @@ define('src/modules/component/axis/axis',['require','d3','builder','./rotate'],f
       transform: "translate(0,0)",
       text: ""
     };
+    var g;
+    var titleText;
 
     function component(selection) {
       selection.each(function () {
@@ -10383,8 +10385,12 @@ define('src/modules/component/axis/axis',['require','d3','builder','./rotate'],f
           .tickPadding(tick.padding)
           .tickFormat(tick.format);
 
-        var g = d3.select(this).append("g")
-          .attr("class", gClass)
+        if (!g) {
+          g = d3.select(this).append("g");
+        }
+
+        // Attach axis
+        g.attr("class", gClass)
           .attr("transform", transform)
           .call(axis);
 
@@ -10396,7 +10402,11 @@ define('src/modules/component/axis/axis',['require','d3','builder','./rotate'],f
           g.call(builder(rotateLabels, rotation));
         }
 
-        g.append("text")
+        if (!titleText) {
+          titleText = g.append("text");
+        }
+
+        titleText.append("text")
           .attr("class", title.class)
           .attr("x", title.x)
           .attr("y", title.y)
@@ -10885,13 +10895,14 @@ define('src/modules/element/svg/rect',['require','d3'],function (require) {
   var d3 = require("d3");
 
   return function rect() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d; };
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var rx = 0;
     var ry = 0;
     var width = null;
     var height = null;
+    var color = d3.scale.category10();
 
     // Options
     var cssClass = "bar";
@@ -10901,12 +10912,9 @@ define('src/modules/element/svg/rect',['require','d3'],function (require) {
     var opacity = 1;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var bars = d3.select(this)
-          .selectAll("." + cssClass)
-          .data(data);
+      selection.each(function (data) {
+        var bars = d3.select(this).selectAll("rect")
+          .data(data, key);
 
         bars.exit().remove();
 
@@ -10928,13 +10936,13 @@ define('src/modules/element/svg/rect',['require','d3'],function (require) {
     }
 
     function colorFill(d, i) {
-      return d3.scale.category10()(i);
+      return color(i);
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 
@@ -11632,7 +11640,7 @@ define('src/modules/element/svg/path',['require','d3'],function (require) {
   var d3 = require("d3");
 
   return function path() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d; };
     var pathGenerator = null;
 
     // Options
@@ -11644,12 +11652,9 @@ define('src/modules/element/svg/path',['require','d3'],function (require) {
     var opacity = 1;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var path = d3.select(this)
-          .selectAll("." + cssClass)
-          .data(data);
+      selection.each(function (data) {
+        var path = d3.select(this).selectAll("path")
+          .data(data, key);
 
         path.exit().remove();
 
@@ -11667,9 +11672,9 @@ define('src/modules/element/svg/path',['require','d3'],function (require) {
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 
@@ -11723,7 +11728,7 @@ define('src/modules/element/svg/text',['require','d3'],function (require) {
   var d3 = require("d3");
 
   return function text() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d; };
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var dx = 0;
@@ -11737,12 +11742,9 @@ define('src/modules/element/svg/text',['require','d3'],function (require) {
     var texts = "";
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var text = d3.select(this)
-          .selectAll("." + cssClass)
-          .data(data);
+      selection.each(function (data) {
+        var text = d3.select(this).selectAll("text")
+          .data(data, key);
 
         text.exit().remove();
 
@@ -11762,9 +11764,9 @@ define('src/modules/element/svg/text',['require','d3'],function (require) {
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 
@@ -12087,12 +12089,15 @@ define('src/modules/component/clippath',['require','d3'],function (require) {
     var y = 0;
     var width = 0;
     var height = 0;
+    var g;
 
     function element(selection) {
       selection.each(function () {
-        d3.select(this)
-          .append("clipPath")
-          .attr("id", id)
+        if (!g) {
+          g = d3.select(this).append("clipPath");
+        }
+
+        g.attr("id", id)
           .attr("transform", transform)
           .append("rect")
           .attr("x", x)
@@ -12167,6 +12172,7 @@ define('src/modules/component/events/brush',['require','d3'],function (require) 
     var brushStartCallback = [];
     var brushCallback = [];
     var brushEndCallback = [];
+    var brushG;
 
     function component(selection) {
       selection.each(function (data, index) {
@@ -12199,8 +12205,12 @@ define('src/modules/component/events/brush',['require','d3'],function (require) 
         if (extent) { brush.extent(extent); }
         if (clamp) { brush.clamp(clamp); }
 
-        var brushG = d3.select(this).append("g")
-          .attr("class", cssClass)
+        if (!brushG) {
+          brushG = d3.select(this).append("g");
+        }
+
+        // Attach new brush
+        brushG.attr("class", cssClass)
           .attr("opacity", opacity)
           .call(brush)
           .selectAll("rect");
@@ -12296,11 +12306,12 @@ define('src/modules/element/svg/line',['require','d3'],function (require) {
   var d3 = require("d3");
 
   return function line() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d; };
     var x1 = 0;
     var x2 = 0;
     var y1 = 0;
     var y2 = 0;
+    var color = d3.scale.category10();
 
     var cssClass = "line";
     var stroke = colorFill;
@@ -12308,12 +12319,9 @@ define('src/modules/element/svg/line',['require','d3'],function (require) {
     var opacity = 1;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var lines = d3.select(this)
-          .selectAll("." + cssClass)
-          .data(data);
+      selection.each(function (data) {
+        var lines = d3.select(this).selectAll("line")
+          .data(data, key);
 
         // Exit
         lines.exit().remove();
@@ -12335,13 +12343,13 @@ define('src/modules/element/svg/line',['require','d3'],function (require) {
     }
 
     function colorFill(d, i) {
-      return d3.scale.category10()(i);
+      return color(i);
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
     
@@ -12419,6 +12427,7 @@ define('src/modules/component/series/area',['require','d3','src/modules/element/
       strokeWidth: 0,
       opacity: 1
     };
+    var area;
 
     function component(selection) {
       selection.each(function () {
@@ -12429,9 +12438,11 @@ define('src/modules/component/series/area',['require','d3','src/modules/element/
 
         var areaPath = path().pathGenerator(areas);
 
-        d3.select(this)
-          .append("g")
-          .call(builder(properties, areaPath));
+        if (!area) {
+          area = d3.select(this).append("g");
+        }
+
+        area.call(builder(properties, areaPath));
       });
     }
 
@@ -12542,6 +12553,7 @@ define('src/modules/component/series/bars',['require','d3','src/modules/element/
       strokeWidth: 0,
       opacity: 1
     };
+    var bars;
 
     function component(selection) {
       selection.each(function (data) {
@@ -12588,11 +12600,21 @@ define('src/modules/component/series/bars',['require','d3','src/modules/element/
           .rx(rx)
           .ry(ry);
 
-        d3.select(this).append("g")
-          .selectAll("g")
-          .data(data)
-          .enter().append("g")
-          .call(builder(properties, rects));
+        if (!bars) {
+          bars = d3.select(this).append("g");
+        }
+
+        bars.selectAll("g")
+          .data(data);
+
+        // Exit
+        bars.exit().remove();
+
+        // Enter
+        bars.enter().append("g");
+
+        // Update
+        bars.call(builder(properties, rects));
       });
     }
 
@@ -12674,10 +12696,11 @@ define('src/modules/element/svg/circle',['require','d3'],function (require) {
   var d3 = require("d3");
 
   return function circle() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d; };
     var cx = function (d) { return d.x; };
     var cy = function (d) { return d.y; };
     var radius = 5;
+    var color = d3.scale.category10();
 
     // Options
     var cssClass = "circles";
@@ -12687,12 +12710,9 @@ define('src/modules/element/svg/circle',['require','d3'],function (require) {
     var opacity = null;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var circles = d3.select(this)
-          .selectAll("." + cssClass)
-          .data(data);
+      selection.each(function (data) {
+        var circles = d3.select(this).selectAll("circle")
+          .data(data, key);
 
         // Exit
         circles.exit().remove();
@@ -12715,13 +12735,13 @@ define('src/modules/element/svg/circle',['require','d3'],function (require) {
     }
 
     function colorFill (d, i) {
-      return d3.scale.category10()(i);
+      return color(i);
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 
@@ -12797,6 +12817,7 @@ define('src/modules/component/series/points',['require','d3','src/modules/elemen
       strokeWidth: 0,
       opacity: 1
     };
+    var point;
 
     function component(selection) {
       selection.each(function (data) {
@@ -12805,8 +12826,11 @@ define('src/modules/component/series/points',['require','d3','src/modules/elemen
           .cy(Y)
           .radius(radius);
 
-        d3.select(this).append("g")
-          .datum(data.reduce(function (a, b) {
+        if (!point) {
+          point = d3.select(this).append("g");
+        }
+
+        point.datum(data.reduce(function (a, b) {
             return a.concat(b);
           },[]).filter(y))
           .call(builder(properties, circles));
@@ -12888,19 +12912,22 @@ define('src/modules/component/series/line',['require','d3','src/modules/element/
       strokeWidth: 3,
       opacity: 1
     };
+    var lines;
 
     function component(selection) {
       selection.each(function () {
-        var lines = d3.svg.line().x(X).y(Y)
+        var line = d3.svg.line().x(X).y(Y)
           .interpolate(interpolate)
           .tension(tension)
           .defined(defined);
 
-        var linePath = path().pathGenerator(lines);
+        var linePath = path().pathGenerator(line);
 
-        d3.select(this)
-          .append("g")
-          .call(builder(properties, linePath));
+        if (!lines) {
+          lines = d3.select(this).append("g");
+        }
+
+        lines.call(builder(properties, linePath));
       });
     }
 
@@ -13847,11 +13874,12 @@ define('src/modules/element/svg/ellipse',['require','d3'],function (require) {
   var d3 = require("d3");
 
   return function ellipse() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d; };
     var cx = function (d) { return d.x; };
     var cy = function (d) { return d.y; };
     var rx = 20;
     var ry = 20;
+    var color = d3.scale.catgory10();
 
     // Options
     var cssClass = "ellipses";
@@ -13862,11 +13890,8 @@ define('src/modules/element/svg/ellipse',['require','d3'],function (require) {
 
     function element(selection) {
       selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var ellipses = d3.select(this)
-          .selectAll("." + cssClass)
-          .data(data);
+        var ellipses = d3.select(this).selectAll("ellipse")
+          .data(data, key);
 
         // Exit
         ellipses.exit().remove();
@@ -13889,13 +13914,13 @@ define('src/modules/element/svg/ellipse',['require','d3'],function (require) {
     }
 
     function colorFill(d, i) {
-      return d3.scale.category10()(i);
+      return color(i);
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 
@@ -13961,7 +13986,7 @@ define('src/modules/element/svg/image',['require','d3'],function (require) {
   var d3 = require("d3");
 
   return function image() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d; };
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var width = 10;
@@ -13973,12 +13998,9 @@ define('src/modules/element/svg/image',['require','d3'],function (require) {
     var cssClass = "image";
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var images = d3.select(this)
-          .selectAll("." + cssClass)
-          .data(data);
+      selection.each(function (data) {
+        var images = d3.select(this).selectAll("image")
+          .data(data, key);
 
         // Exit
         images.exit().remove();
@@ -13999,9 +14021,9 @@ define('src/modules/element/svg/image',['require','d3'],function (require) {
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
     

--- a/src/modules/component/axis/axis.js
+++ b/src/modules/component/axis/axis.js
@@ -37,6 +37,8 @@ define(function (require) {
       transform: "translate(0,0)",
       text: ""
     };
+    var g;
+    var titleText;
 
     function component(selection) {
       selection.each(function () {
@@ -51,14 +53,12 @@ define(function (require) {
           .tickPadding(tick.padding)
           .tickFormat(tick.format);
 
-        var g = d3.select(this);
-
-        // Remove previous axis
-        g.select("g." + gClass).remove();
+        if (!g) {
+          g = d3.select(this).append("g");
+        }
 
         // Attach axis
-        g.append("g")
-          .attr("class", gClass)
+        g.attr("class", gClass)
           .attr("transform", transform)
           .call(axis);
 
@@ -70,7 +70,11 @@ define(function (require) {
           g.call(builder(rotateLabels, rotation));
         }
 
-        g.append("text")
+        if (!titleText) {
+          titleText = g.append("text");
+        }
+
+        titleText.append("text")
           .attr("class", title.class)
           .attr("x", title.x)
           .attr("y", title.y)

--- a/src/modules/component/boxplot.js
+++ b/src/modules/component/boxplot.js
@@ -122,7 +122,7 @@ define(function (require) {
       });
     }
 
-    component.gClass = function (_) {
+    component.class = function (_) {
       if (!arguments.length) { return gClass; }
       gClass = _;
       return component;

--- a/src/modules/component/clippath.js
+++ b/src/modules/component/clippath.js
@@ -8,16 +8,15 @@ define(function (require) {
     var y = 0;
     var width = 0;
     var height = 0;
+    var g;
 
     function element(selection) {
       selection.each(function () {
-        var g = d3.select(this);
+        if (!g) {
+          g = d3.select(this).append("clipPath");
+        }
 
-        // Remove previous clip-path
-        g.select("clipPath").remove();
-
-        g.append("clipPath")
-          .attr("id", id)
+        g.attr("id", id)
           .attr("transform", transform)
           .append("rect")
           .attr("x", x)

--- a/src/modules/component/events/brush.js
+++ b/src/modules/component/events/brush.js
@@ -18,6 +18,7 @@ define(function (require) {
     var brushStartCallback = [];
     var brushCallback = [];
     var brushEndCallback = [];
+    var brushG;
 
     function component(selection) {
       selection.each(function (data, index) {
@@ -50,14 +51,12 @@ define(function (require) {
         if (extent) { brush.extent(extent); }
         if (clamp) { brush.clamp(clamp); }
 
-        var brushG = d3.select(this);
-
-        // Remove previous brush
-        brushG.select("g." + cssClass).remove();
+        if (!brushG) {
+          brushG = d3.select(this).append("g");
+        }
 
         // Attach new brush
-        brushG.append("g")
-          .attr("class", cssClass)
+        brushG.attr("class", cssClass)
           .attr("opacity", opacity)
           .call(brush)
           .selectAll("rect");

--- a/src/modules/component/series/area.js
+++ b/src/modules/component/series/area.js
@@ -21,7 +21,7 @@ define(function (require) {
       strokeWidth: 0,
       opacity: 1
     };
-    var area;
+    var g;
 
     function component(selection) {
       selection.each(function () {
@@ -32,11 +32,11 @@ define(function (require) {
 
         var areaPath = path().pathGenerator(areas);
 
-        if (!area) {
-          area = d3.select(this).append("g");
+        if (!g) {
+          g = d3.select(this).append("g");
         }
 
-        area.call(builder(properties, areaPath));
+        g.call(builder(properties, areaPath));
       });
     }
 

--- a/src/modules/component/series/area.js
+++ b/src/modules/component/series/area.js
@@ -21,6 +21,7 @@ define(function (require) {
       strokeWidth: 0,
       opacity: 1
     };
+    var area;
 
     function component(selection) {
       selection.each(function () {
@@ -31,9 +32,11 @@ define(function (require) {
 
         var areaPath = path().pathGenerator(areas);
 
-        d3.select(this)
-          .append("g")
-          .call(builder(properties, areaPath));
+        if (!area) {
+          area = d3.select(this).append("g");
+        }
+
+        area.call(builder(properties, areaPath));
       });
     }
 

--- a/src/modules/component/series/bars.js
+++ b/src/modules/component/series/bars.js
@@ -24,7 +24,6 @@ define(function (require) {
       strokeWidth: 0,
       opacity: 1
     };
-
     var g;
 
     function component(selection) {

--- a/src/modules/component/series/bars.js
+++ b/src/modules/component/series/bars.js
@@ -25,6 +25,8 @@ define(function (require) {
       opacity: 1
     };
 
+    var g;
+
     function component(selection) {
       selection.each(function (data) {
         var timeNotation = parseTime(interval);
@@ -70,11 +72,21 @@ define(function (require) {
           .rx(rx)
           .ry(ry);
 
-        d3.select(this).append("g")
-          .selectAll("g")
-          .data(data)
-          .enter().append("g")
-          .call(builder(properties, rects));
+        if (!g) {
+          g = d3.select(this).append("g");
+        }
+
+        var bars = g.selectAll("g")
+          .data(data);
+
+        // Exit
+        bars.exit().remove();
+
+        // Enter
+        bars.enter().append("g");
+
+        // Update
+        bars.call(builder(properties, rects));
       });
     }
 

--- a/src/modules/component/series/line.js
+++ b/src/modules/component/series/line.js
@@ -20,7 +20,7 @@ define(function (require) {
       strokeWidth: 3,
       opacity: 1
     };
-    var lines;
+    var g;
 
     function component(selection) {
       selection.each(function () {
@@ -31,11 +31,11 @@ define(function (require) {
 
         var linePath = path().pathGenerator(line);
 
-        if (!lines) {
-          lines = d3.select(this).append("g");
+        if (!g) {
+          g = d3.select(this).append("g");
         }
 
-        lines.call(builder(properties, linePath));
+        g.call(builder(properties, linePath));
       });
     }
 

--- a/src/modules/component/series/line.js
+++ b/src/modules/component/series/line.js
@@ -20,19 +20,22 @@ define(function (require) {
       strokeWidth: 3,
       opacity: 1
     };
+    var lines;
 
     function component(selection) {
       selection.each(function () {
-        var lines = d3.svg.line().x(X).y(Y)
+        var line = d3.svg.line().x(X).y(Y)
           .interpolate(interpolate)
           .tension(tension)
           .defined(defined);
 
-        var linePath = path().pathGenerator(lines);
+        var linePath = path().pathGenerator(line);
 
-        d3.select(this)
-          .append("g")
-          .call(builder(properties, linePath));
+        if (!lines) {
+          lines = d3.select(this).append("g");
+        }
+
+        lines.call(builder(properties, linePath));
       });
     }
 

--- a/src/modules/component/series/points.js
+++ b/src/modules/component/series/points.js
@@ -18,6 +18,7 @@ define(function (require) {
       strokeWidth: 0,
       opacity: 1
     };
+    var point;
 
     function component(selection) {
       selection.each(function (data) {
@@ -26,8 +27,11 @@ define(function (require) {
           .cy(Y)
           .radius(radius);
 
-        d3.select(this).append("g")
-          .datum(data.reduce(function (a, b) {
+        if (!point) {
+          point = d3.select(this).append("g");
+        }
+
+        point.datum(data.reduce(function (a, b) {
             return a.concat(b);
           },[]).filter(y))
           .call(builder(properties, circles));

--- a/src/modules/component/series/points.js
+++ b/src/modules/component/series/points.js
@@ -18,7 +18,7 @@ define(function (require) {
       strokeWidth: 0,
       opacity: 1
     };
-    var point;
+    var g;
 
     function component(selection) {
       selection.each(function (data) {
@@ -27,11 +27,11 @@ define(function (require) {
           .cy(Y)
           .radius(radius);
 
-        if (!point) {
-          point = d3.select(this).append("g");
+        if (!g) {
+          g = d3.select(this).append("g");
         }
 
-        point.datum(data.reduce(function (a, b) {
+        g.datum(data.reduce(function (a, b) {
             return a.concat(b);
           },[]).filter(y))
           .call(builder(properties, circles));

--- a/src/modules/element/svg/circle.js
+++ b/src/modules/element/svg/circle.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function circle() {
-    var key = function (d) { return d.x; };
+    var key = null;
     var cx = function (d) { return d.x; };
     var cy = function (d) { return d.y; };
     var radius = 5;
@@ -18,7 +18,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var circles = d3.select(this).selectAll("circle")
-          .data(data);
+          .data(data, key);
 
         // Exit
         circles.exit().remove();

--- a/src/modules/element/svg/circle.js
+++ b/src/modules/element/svg/circle.js
@@ -2,10 +2,11 @@ define(function (require) {
   var d3 = require("d3");
 
   return function circle() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d.x; };
     var cx = function (d) { return d.x; };
     var cy = function (d) { return d.y; };
     var radius = 5;
+    var color = d3.scale.category10();
 
     // Options
     var cssClass = "circles";
@@ -15,11 +16,8 @@ define(function (require) {
     var opacity = null;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var circles = d3.select(this)
-          .selectAll("." + cssClass)
+      selection.each(function (data) {
+        var circles = d3.select(this).selectAll("circle")
           .data(data);
 
         // Exit
@@ -43,13 +41,13 @@ define(function (require) {
     }
 
     function colorFill (d, i) {
-      return d3.scale.category10()(i);
+      return color(i);
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 

--- a/src/modules/element/svg/ellipse.js
+++ b/src/modules/element/svg/ellipse.js
@@ -2,11 +2,12 @@ define(function (require) {
   var d3 = require("d3");
 
   return function ellipse() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d.x; };
     var cx = function (d) { return d.x; };
     var cy = function (d) { return d.y; };
     var rx = 20;
     var ry = 20;
+    var color = d3.scale.catgory10();
 
     // Options
     var cssClass = "ellipses";
@@ -16,11 +17,8 @@ define(function (require) {
     var opacity = null;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var ellipses = d3.select(this)
-          .selectAll("." + cssClass)
+      selection.each(function (data) {
+        var ellipses = d3.select(this).selectAll("ellipse")
           .data(data);
 
         // Exit
@@ -44,13 +42,13 @@ define(function (require) {
     }
 
     function colorFill(d, i) {
-      return d3.scale.category10()(i);
+      return color(i);
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 

--- a/src/modules/element/svg/ellipse.js
+++ b/src/modules/element/svg/ellipse.js
@@ -7,7 +7,7 @@ define(function (require) {
     var cy = function (d) { return d.y; };
     var rx = 20;
     var ry = 20;
-    var color = d3.scale.catgory10();
+    var color = d3.scale.category10();
 
     // Options
     var cssClass = "ellipses";

--- a/src/modules/element/svg/ellipse.js
+++ b/src/modules/element/svg/ellipse.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function ellipse() {
-    var key = function (d) { return d.x; };
+    var key = null;
     var cx = function (d) { return d.x; };
     var cy = function (d) { return d.y; };
     var rx = 20;
@@ -19,7 +19,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var ellipses = d3.select(this).selectAll("ellipse")
-          .data(data);
+          .data(data, key);
 
         // Exit
         ellipses.exit().remove();

--- a/src/modules/element/svg/image.js
+++ b/src/modules/element/svg/image.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function image() {
-    var key = function (d) { return d.x; };
+    var key = null;
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var width = 10;
@@ -16,7 +16,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var images = d3.select(this).selectAll("image")
-          .data(data);
+          .data(data, key);
 
         // Exit
         images.exit().remove();

--- a/src/modules/element/svg/image.js
+++ b/src/modules/element/svg/image.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function image() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d.x; };
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var width = 10;
@@ -14,11 +14,8 @@ define(function (require) {
     var cssClass = "image";
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var images = d3.select(this)
-          .selectAll("." + cssClass)
+      selection.each(function (data) {
+        var images = d3.select(this).selectAll("image")
           .data(data);
 
         // Exit
@@ -40,9 +37,9 @@ define(function (require) {
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
     

--- a/src/modules/element/svg/line.js
+++ b/src/modules/element/svg/line.js
@@ -2,11 +2,12 @@ define(function (require) {
   var d3 = require("d3");
 
   return function line() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d.x; };
     var x1 = 0;
     var x2 = 0;
     var y1 = 0;
     var y2 = 0;
+    var color = d3.scale.category10();
 
     var cssClass = "line";
     var stroke = colorFill;
@@ -14,11 +15,8 @@ define(function (require) {
     var opacity = 1;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var lines = d3.select(this)
-          .selectAll("." + cssClass)
+      selection.each(function (data) {
+        var lines = d3.select(this).selectAll("line")
           .data(data);
 
         // Exit
@@ -41,13 +39,13 @@ define(function (require) {
     }
 
     function colorFill(d, i) {
-      return d3.scale.category10()(i);
+      return color(i);
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
     

--- a/src/modules/element/svg/line.js
+++ b/src/modules/element/svg/line.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function line() {
-    var key = function (d) { return d.x; };
+    var key = null;
     var x1 = 0;
     var x2 = 0;
     var y1 = 0;
@@ -17,7 +17,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var lines = d3.select(this).selectAll("line")
-          .data(data);
+          .data(data, null);
 
         // Exit
         lines.exit().remove();

--- a/src/modules/element/svg/line.js
+++ b/src/modules/element/svg/line.js
@@ -17,7 +17,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var lines = d3.select(this).selectAll("line")
-          .data(data, null);
+          .data(data, key);
 
         // Exit
         lines.exit().remove();

--- a/src/modules/element/svg/path.js
+++ b/src/modules/element/svg/path.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function path() {
-    var key = function (d) { return d.x; };
+    var key = null;
     var pathGenerator = null;
 
     // Options
@@ -16,7 +16,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var path = d3.select(this).selectAll("path")
-          .data(data);
+          .data(data, key);
 
         path.exit().remove();
 

--- a/src/modules/element/svg/path.js
+++ b/src/modules/element/svg/path.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function path() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d.x; };
     var pathGenerator = null;
 
     // Options
@@ -14,11 +14,8 @@ define(function (require) {
     var opacity = 1;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var path = d3.select(this)
-          .selectAll("." + cssClass)
+      selection.each(function (data) {
+        var path = d3.select(this).selectAll("path")
           .data(data);
 
         path.exit().remove();
@@ -37,9 +34,9 @@ define(function (require) {
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 

--- a/src/modules/element/svg/rect.js
+++ b/src/modules/element/svg/rect.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function rect() {
-    var key = function (d) { return d.x; };
+    var key = null;
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var rx = 0;
@@ -21,7 +21,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var bars = d3.select(this).selectAll("rect")
-          .data(data);
+          .data(data, key);
 
         bars.exit().remove();
 

--- a/src/modules/element/svg/rect.js
+++ b/src/modules/element/svg/rect.js
@@ -2,13 +2,14 @@ define(function (require) {
   var d3 = require("d3");
 
   return function rect() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d.x; };
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var rx = 0;
     var ry = 0;
     var width = null;
     var height = null;
+    var color = d3.scale.category10();
 
     // Options
     var cssClass = "bar";
@@ -18,11 +19,8 @@ define(function (require) {
     var opacity = 1;
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var bars = d3.select(this)
-          .selectAll("." + cssClass)
+      selection.each(function (data) {
+        var bars = d3.select(this).selectAll("rect")
           .data(data);
 
         bars.exit().remove();
@@ -45,13 +43,13 @@ define(function (require) {
     }
 
     function colorFill(d, i) {
-      return d3.scale.category10()(i);
+      return color(i);
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 

--- a/src/modules/element/svg/text.js
+++ b/src/modules/element/svg/text.js
@@ -18,7 +18,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var text = d3.select(this).selectAll("text")
-          .data(data, null);
+          .data(data, key);
 
         text.exit().remove();
 

--- a/src/modules/element/svg/text.js
+++ b/src/modules/element/svg/text.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function text() {
-    var key = function (d) { return d.x; };
+    var key = null;
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var dx = 0;
@@ -18,7 +18,7 @@ define(function (require) {
     function element(selection) {
       selection.each(function (data) {
         var text = d3.select(this).selectAll("text")
-          .data(data);
+          .data(data, null);
 
         text.exit().remove();
 

--- a/src/modules/element/svg/text.js
+++ b/src/modules/element/svg/text.js
@@ -2,7 +2,7 @@ define(function (require) {
   var d3 = require("d3");
 
   return function text() {
-    var accessor = function (d) { return d; };
+    var key = function (d) { return d.x; };
     var x = function (d) { return d.x; };
     var y = function (d) { return d.y; };
     var dx = 0;
@@ -16,11 +16,8 @@ define(function (require) {
     var texts = "";
 
     function element(selection) {
-      selection.each(function (data, index) {
-        data = accessor.call(this, data, index);
-
-        var text = d3.select(this)
-          .selectAll("." + cssClass)
+      selection.each(function (data) {
+        var text = d3.select(this).selectAll("text")
           .data(data);
 
         text.exit().remove();
@@ -41,9 +38,9 @@ define(function (require) {
     }
 
     // Public API
-    element.accessor = function (_) {
-      if (!arguments.length) { return accessor; }
-      accessor = _;
+    element.key = function (_) {
+      if (!arguments.length) { return key; }
+      key = _;
       return element;
     };
 

--- a/test/unit/specs/modules/element/circle.js
+++ b/test/unit/specs/modules/element/circle.js
@@ -26,26 +26,6 @@ define(function (require) {
       chai.assert.equal(isFunction, true);
     });
 
-    describe("accessor API", function () {
-      var defaultAccessor;
-
-      beforeEach(function () {
-        removeChildren(fixture);
-        defaultAccessor = function (d) { return d; };
-        element.accessor(defaultAccessor);
-      });
-
-      it("should get the property", function () {
-        chai.assert.equal(element.accessor(), defaultAccessor);
-      });
-
-      it("should set the property", function () {
-        var newAccessor = function (d) { return d.series; };
-        element.accessor(newAccessor);
-        chai.assert.equal(element.accessor(), newAccessor);
-      });
-    });
-
     describe("cx API", function () {
       var defaultCX;
 

--- a/test/unit/specs/modules/element/path.js
+++ b/test/unit/specs/modules/element/path.js
@@ -59,25 +59,6 @@ define(function (require) {
       });
     });
 
-    describe("accessor API", function () {
-      var defaultAccessor;
-
-      beforeEach(function () {
-        defaultAccessor = function (d) { return d; };
-        element.accessor(defaultAccessor);
-      });
-
-      it("should get the property", function () {
-        chai.assert.equal(element.accessor(), defaultAccessor);
-      });
-
-      it("should set the property", function () {
-        var newAccessor = function (d) { return d.values; };
-        element.accessor(newAccessor);
-        chai.assert.equal(element.accessor(), newAccessor);
-      });
-    });
-
     describe("transform API", function () {
       var defaultTransform;
       var newTransform;


### PR DESCRIPTION
Using joins with D3 significantly reduces the overhead of recreating dynamic components. When a component is redrawn, the component should not have to be removed. Using data joins, we can resize, redraw, etc components without having to tear down the chart and redraw it again.

Having to constantly tear down charts is a good source of problems for memory leaks.

This pull request refactors components so that they support doing data joins.
